### PR TITLE
Not-super-meaningful update of social network URLs to be HTTPS

### DIFF
--- a/Classes/Controllers/SFLegislatorDetailViewController.m
+++ b/Classes/Controllers/SFLegislatorDetailViewController.m
@@ -346,6 +346,10 @@ NSDictionary *_socialImages;
     NSString *addressNoOfficeNum = [[_legislator.congressOffice stringByTrimmingLeadingCharactersInSet:[NSCharacterSet decimalDigitCharacterSet]]
                                     stringByTrimmingLeadingAndTrailingWhitespaceAndNewlineCharacters];
     NSString *escapedAddress = [[addressNoOfficeNum stringByAppendingString:@", Washington, DC"] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+
+    // visiting https://maps.apple.com throws an error, so I assume it's not supported.
+    // this is submitting an address, so it'd be nice to have this behind HTTPS.
+
     NSURL *mapSearchURL = [NSURL URLWithFormat:@"http://maps.apple.com/?q=%@", escapedAddress];
     BOOL urlOpened = [[UIApplication sharedApplication] openURL:mapSearchURL];
 #if CONFIGURATION_Beta

--- a/Classes/Models/SFLegislator.m
+++ b/Classes/Models/SFLegislator.m
@@ -190,7 +190,7 @@
         return nil;
     }
     if (!_facebookURL) {
-        _facebookURL = [NSURL URLWithFormat:@"http://facebook.com/%@", self.facebookId];
+        _facebookURL = [NSURL URLWithFormat:@"https://facebook.com/%@", self.facebookId];
     }
     return _facebookURL;
 }
@@ -200,7 +200,7 @@
         return nil;
     }
     if (!_twitterURL) {
-        _twitterURL = [NSURL URLWithFormat:@"http://twitter.com/%@", self.twitterId];
+        _twitterURL = [NSURL URLWithFormat:@"https://twitter.com/%@", self.twitterId];
     }
     return _twitterURL;
 }
@@ -210,7 +210,7 @@
         return nil;
     }
     if (!_youtubeURL) {
-        _youtubeURL = [NSURL URLWithFormat:@"http://youtube.com/%@", self.youtubeId];
+        _youtubeURL = [NSURL URLWithFormat:@"https://youtube.com/%@", self.youtubeId];
     }
     return _youtubeURL;
 }


### PR DESCRIPTION
Just a couple things I spotted in a quick scan - noted that our address search in Apple Maps isn't using HTTPS (and it [doesn't support it](https://maps.apple.com/)), and updated the social media URLs to use the HTTPS version, since they all support that. Not the most impactful PR, but here you go.
